### PR TITLE
Fix genome comparison tooltip, add testing hooks

### DIFF
--- a/src/plugin/modules/widgets/OverviewWidget.js
+++ b/src/plugin/modules/widgets/OverviewWidget.js
@@ -246,22 +246,23 @@ define([
                 var div = html.tag('div');
                 return html.makePanel({
                     title: 'Data Overview',
-                    content: div([
+                    content: div({dataWidget: 'dataview-overview'},[
                         div({dataPlaceholder: 'alert'}),
                         div({dataPlaceholder: 'content'})
                     ])
                 });
             }
-            var div = html.tag('div'),
-                h3 = html.tag('h3'),
-                h4 = html.tag('h4'),
-                span = html.tag('span'),
-                p = html.tag('p'),
-                a = html.tag('a'),
-                table = html.tag('table'),
-                tr = html.tag('tr'),
-                th = html.tag('th'),
-                td = html.tag('td');
+            var t = html.tag,
+                div = t('div'),
+                h3 = t('h3'),
+                h4 = t('h4'),
+                span = t('span'),
+                p = t('p'),
+                a = t('a'),
+                table = t('table'),
+                tr = t('tr'),
+                th = t('th'),
+                td = t('td');
             function renderTitleRow() {
                 return tr({style: {verticalAlign: 'baseline'}}, [
                     th(state.get('dataicon')),
@@ -284,7 +285,7 @@ define([
                 return [
                     tr([
                         th('Module'),
-                        td([
+                        td({dataElement: 'module'},[
                             (function () {
                                 if (state.get('sub.sub')) {
                                     return get('sub.sub') + ' in ';
@@ -297,7 +298,7 @@ define([
                     ]),
                     tr([
                         th('Type'),
-                        td([
+                        td({dataElement: 'module'}, [
                             (function () {
                                 if (state.get('sub.sub')) {
                                     return get('sub.sub') + ' in ';
@@ -315,7 +316,7 @@ define([
                 if (state.get('workspace.metadata.narrative_nice_name')) {
                     return tr([
                         th('In Narrative'),
-                        td(a({href: '/narrative/ws.' + state.get('workspace.id') + '.' + state.get('object.id'),
+                        td({dataElement: 'narrative'}, a({href: '/narrative/ws.' + state.get('workspace.id') + '.' + state.get('object.id'),
                             target: '_blank'}, state.get('workspace.metadata.narrative_nice_name')))
                     ]);
                 }
@@ -335,14 +336,14 @@ define([
                 }
                 return tr([
                     th('Permalink'),
-                    td(a({href: permalink}, permalink))
+                    td({dataElement: 'permalink'}, a({href: permalink}, permalink))
                 ]);
             }
             function renderVersionRow() {
                 var version = state.get('object.version') || 'Latest';
                 return tr([
                     th('Version'),
-                    td(version)
+                    td({dataElement: 'version'}, version)
                 ]);
             }
             function panel(content) {
@@ -477,7 +478,7 @@ define([
                             renderNarrativeRow(),
                             tr([
                                 th('Last Updated'),
-                                td([
+                                td({dataElement: 'last-updated'}, [
                                     dateFormat(state.get('object.save_date')), ' by ', a({href: ['#people', state.get('object.saved_by')].join('/')}, state.get('object.saved_by'))
                                 ])
                             ]),

--- a/src/plugin/modules/widgets/protcmp/kbaseGenomeComparison.js
+++ b/src/plugin/modules/widgets/protcmp/kbaseGenomeComparison.js
@@ -62,7 +62,7 @@ define([
             render: function () {
                 var self = this;
 
-                self.tooltip = d3.select("body").append("div").classed("kbcb-tooltip", true);
+                self.tooltip = d3.select("body").append("div").classed("genome-comparison-tooltip", true);
 
                 var container = this.$elem;
                 container.empty();

--- a/src/plugin/resources/css/dataview.css
+++ b/src/plugin/resources/css/dataview.css
@@ -1071,3 +1071,12 @@ button.kb-method-run:hover {
   font-size: 24pt;
 }
 
+.genome-comparison-tooltip {
+	position: absolute;
+	z-index: 9999999;
+	visibility: hidden;
+	opacity: 0.8;
+	background-color: #222;
+	color: #fff;
+	padding: 0.5em;
+}


### PR DESCRIPTION
The style for the genome comparison tooltip had gone astray, added it to the dataview stylesheet
During a prototype of ui-level testing (browser automation) added a few structural annotations to the overview widget. Structural annotation is necessary if you are going to query the DOM for specific output.
