### PR TITLE
Fix modeling

### DIFF
--- a/src/plugin/modules/widgets/modeling/KBaseBiochem.Media.js
+++ b/src/plugin/modules/widgets/modeling/KBaseBiochem.Media.js
@@ -42,12 +42,14 @@ define([
                 .then(function(cpds) {
                     for (var i = 0; i < self.mediacompounds.length; i++) {
                         var cpd = self.mediacompounds[i];
-                        cpd.name = cpds[i].name;
-                        cpd.formula = cpds[i].formula;
-                        cpd.charge = cpds[i].charge;
-                        cpd.deltaG = cpds[i].deltaG;
-                        cpd.deltaGErr = cpds[i].deltaGErr;
-                        cpd.abbrev = cpds[i].abbrev;
+                        if (cpds[i]){
+                            cpd.name = cpds[i].name;
+                            cpd.formula = cpds[i].formula;
+                            cpd.charge = cpds[i].charge;
+                            cpd.deltaG = cpds[i].deltaG;
+                            cpd.deltaGErr = cpds[i].deltaGErr;
+                            cpd.abbrev = cpds[i].abbrev;
+                        }
                     }
                 });
         };

--- a/src/plugin/modules/widgets/modeling/KBaseFBA.FBAModel.js
+++ b/src/plugin/modules/widgets/modeling/KBaseFBA.FBAModel.js
@@ -364,11 +364,20 @@ define([
                 'label': 'Compound',
                 'data': cpd.dispid
             }, {
+                "label": "Image",
+                "data":  "<img src=http://minedatabase.mcs.anl.gov/compound_images/ModelSEED/"+cpd.id.split("_")[0]+".png style='height:300px !important;'>"
+            },{
                 'label': 'Name',
                 'data': cpd.name
             }, {
                 'label': 'Formula',
                 'data': cpd.formula
+            }, {
+                "label": "InChIKey",
+                "data": cpd.inchikey
+            }, {
+                "label": "SMILES",
+                "data": cpd.smiles
             }, {
                 'label': 'Charge',
                 'data': cpd.charge
@@ -381,6 +390,18 @@ define([
                 token: this.runtime.service('session').getAuthToken(),
                 module: 'BiochemistryAPI'
             });
+            if (cpd.smiles && cpd.cpdkbid == "cpd00000") {
+                var p = client.callFunc('depict_compounds', [{
+                    structures: [cpd.smiles]
+                }]).then(function(data) {
+                        output[1] = {
+                            "label": "Image",
+                            "data": data[0]
+                        };
+                        return output;
+                    });
+                return p;
+            }
             if (cpd.cpdkbid !== 'cpd00000') {
                 return client.callFunc('get_compounds', [{
                     compounds: [cpd.cpdkbid],

--- a/src/plugin/modules/widgets/modeling/KBaseFBA.FBAModel.js
+++ b/src/plugin/modules/widgets/modeling/KBaseFBA.FBAModel.js
@@ -549,7 +549,7 @@ define([
                             var abscoef = Math.round(-1 * 100 * biocpd.coefficient) / 100;
                             reactants += '(' + abscoef + ') ';
                         }
-                        reactants += biocpd.name + '[' + biocpd.cmpkbid + ']';
+                        reactants += '<a class="id-click" data-id="'+biocpd.cpdkbid+'" data-method="CompoundTab">'+this.cpdhash[biocpd.cpdkbid].name+"["+this.cpdhash[biocpd.cpdkbid].cmpkbid+"]</a>";
                     } else {
                         if (products.length > 0) {
                             products += ' + ';
@@ -558,7 +558,7 @@ define([
                             var abscoef = Math.round(100 * biocpd.coefficient) / 100;
                             products += '(' + abscoef + ') ';
                         }
-                        products += biocpd.name + '[' + biocpd.cmpkbid + ']';
+                        products += '<a class="id-click" data-id="'+biocpd.cpdkbid+'" data-method="CompoundTab">'+this.cpdhash[biocpd.cpdkbid].name+"["+this.cpdhash[biocpd.cpdkbid].cmpkbid+"]</a>";
                     }
                 }
                 biomass.equation = reactants + ' => ' + products;

--- a/src/plugin/modules/widgets/modeling/kbaseTabTable.js
+++ b/src/plugin/modules/widgets/modeling/kbaseTabTable.js
@@ -514,9 +514,8 @@ define([
                     });
             };
 
-            /* TODO: replace these remote calls with locally installed images. */
             this.compoundImage = function(id) {
-                return 'http://bioseed.mcs.anl.gov/~chenry/jpeg/' + id + '.jpeg';
+                return "<img src=http://minedatabase.mcs.anl.gov/compound_images/ModelSEED/"+id.split("_")[0]+".png style='height:300px !important;'>"
             };
 
             var imageURL = 'http://bioseed.mcs.anl.gov/~chenry/jpeg/';


### PR DESCRIPTION
3 changes to update model and media landing pages to match narrative widgets:
1. handle missing data in custom media compounds
2. add images to model compound pages
3. link from reactions to compound tabs

Mostly pulled from the working narrative code but I did have to make some changes to the compound images to fit the existing style. Hopefully it works pretty well.