### PR TITLE
Add hacky url replacement to fix services endpoint on narrative-dev

### DIFF
--- a/src/plugin/modules/widgets/relatedData.js
+++ b/src/plugin/modules/widgets/relatedData.js
@@ -22,6 +22,9 @@ function (
             const config = this.runtime.rawConfig();
             // Not sure how to get the root services endpoint, so getting it from Workspace
             this.kbaseEndpoint = config.services.Workspace.url.replace(/ws$/, '');
+            this.kbaseEndpoint = this.kbaseEndpoint
+              .replace(/^https:\/\/narrative-dev\./, 'https://')
+              .replace(/^https:\/\/narrative\./, 'https://');
             this.narrURL = config.services.narrative.url;
         }
 

--- a/src/plugin/modules/widgets/relatedData.js
+++ b/src/plugin/modules/widgets/relatedData.js
@@ -1,11 +1,12 @@
 define([
     'kb_common/html',
     'plugins/dataview/modules/collapsiblePanel',
-    'bootstrap'
+    'kb_common/jsonRpc/dynamicServiceClient'
 ],
 function (
     html,
-    collapsiblePanel
+    collapsiblePanel,
+    DynamicServiceClient
 ) {
     'use strict';
 
@@ -18,15 +19,19 @@ function (
             // Both of the props below are assigned in the attach method
             this.hostNode = null;
             this.container = null;
-            this.authToken = this.runtime.service('session').getAuthToken();
-            const config = this.runtime.rawConfig();
+            this.authToken = runtime.service('session').getAuthToken();
             // Not sure how to get the root services endpoint, so getting it from Workspace
-            this.kbaseEndpoint = config.services.Workspace.url.replace(/\/ws$/, '');
             // For narrative-dev and prod, the services endpoint should not have a subdomain
-            this.kbaseEndpoint = this.kbaseEndpoint
-              .replace(/^https:\/\/narrative-dev\./, 'https://')
-              .replace(/^https:\/\/narrative\./, 'https://');
-            this.narrURL = config.services.narrative.url;
+            this.kbaseEndpoint = runtime.config('services.Workspace.url')
+                .replace(/\/ws$/, '') // remove the "/ws" suffix
+                .replace(/^https:\/\/narrative-dev\./, 'https://')
+                .replace(/^https:\/\/narrative\./, 'https://');
+            this.narrURL = runtime.config('services.narrative.url');
+            window.sketchService = new DynamicServiceClient({
+                module: 'sketch_service',
+                url: runtime.config('services.service_wizard.url')
+                // token: runtime.service('session').getAuthToken()
+            });
         }
 
         dataLayout({ upa }) {
@@ -62,12 +67,21 @@ function (
                 kbaseEndpoint: this.kbaseEndpoint,
                 relEngURL: this.kbaseEndpoint + '/relation_engine_api'
             };
+            // Get the sketch service URL
+            const client = new DynamicServiceClient({
+                module: 'sketch_service',
+                url: this.runtime.config('services.service_wizard.url')
+            });
             // When the iframe content finishes loading, send a post message to it
             iframeElm.addEventListener('load', () => {
-                iframeElm.contentWindow.postMessage(JSON.stringify({
-                    method: 'setConfig',
-                    params: { config }
-                }), '*');
+                // Call the sketch client lookupModule method, which returns a promise
+                client.lookupModule().then(mod => {
+                    config.sketchURL = mod[0].url
+                    iframeElm.contentWindow.postMessage(JSON.stringify({
+                        method: 'setConfig',
+                        params: { config }
+                    }), '*');
+                });
             });
         }
 

--- a/src/plugin/modules/widgets/relatedData.js
+++ b/src/plugin/modules/widgets/relatedData.js
@@ -22,6 +22,7 @@ function (
             const config = this.runtime.rawConfig();
             // Not sure how to get the root services endpoint, so getting it from Workspace
             this.kbaseEndpoint = config.services.Workspace.url.replace(/ws$/, '');
+            // For narrative-dev and prod, the services endpoint should not have a subdomain
             this.kbaseEndpoint = this.kbaseEndpoint
               .replace(/^https:\/\/narrative-dev\./, 'https://')
               .replace(/^https:\/\/narrative\./, 'https://');

--- a/src/plugin/modules/widgets/relatedData.js
+++ b/src/plugin/modules/widgets/relatedData.js
@@ -21,7 +21,7 @@ function (
             this.authToken = this.runtime.service('session').getAuthToken();
             const config = this.runtime.rawConfig();
             // Not sure how to get the root services endpoint, so getting it from Workspace
-            this.kbaseEndpoint = config.services.Workspace.url.replace(/ws$/, '');
+            this.kbaseEndpoint = config.services.Workspace.url.replace(/\/ws$/, '');
             // For narrative-dev and prod, the services endpoint should not have a subdomain
             this.kbaseEndpoint = this.kbaseEndpoint
               .replace(/^https:\/\/narrative-dev\./, 'https://')


### PR DESCRIPTION
On narrative-dev, I'm seeing this kbase endpoint url set as `https://narrative-dev.kbase.us/services`, which doesn't work

This is hacky.. if there's a better way get the `kbase.us/services` url from the environment, let me know and I'll be happy to update.