### PR TITLE
derive scientific name from re as well.

### DIFF
--- a/src/plugin/iframe_root/modules/widgets/genomes/kbaseGenomeWideTaxonomy.js
+++ b/src/plugin/iframe_root/modules/widgets/genomes/kbaseGenomeWideTaxonomy.js
@@ -70,6 +70,7 @@ define([
             $row.append($taxonomyColumn);
 
             // This area for the RE taxonomy widget
+            // console.log('genome info?', this.genomeInfo);
             var $reTaxonomyinfo = $('<div>');
             $taxonomyColumn.append($makeTitle('New Lineage'));
             $taxonomyColumn.append($reTaxonomyinfo);
@@ -237,6 +238,7 @@ define([
             $reTaxonomyinfo.KBaseGenomeRELineage({
                 genomeInfo: this.genomeInfo,
                 genomeRef: this.options.genomeRef,
+                timestamp: new Date(this.genomeInfo.created).getTime(),
                 runtime: this.runtime
             });
 


### PR DESCRIPTION
pass obj creation time to the lineage widget for queries
(but not used since it breaks due to incomplete re db.)
better handling for missing taxon